### PR TITLE
Feature/client graphic changes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10600,8 +10600,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10644,8 +10643,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -10656,8 +10654,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10774,8 +10771,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10787,7 +10783,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -10817,7 +10812,6 @@
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10836,7 +10830,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -10940,7 +10933,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11018,8 +11010,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11055,7 +11046,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11075,7 +11065,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11119,14 +11108,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11747,7 +11734,6 @@
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11766,7 +11752,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -11948,8 +11933,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12055,8 +12039,7 @@
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.html
+++ b/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.html
@@ -26,10 +26,14 @@
       </div>
     </div>
 
-    <div *ngIf="tags.length" class="tags">
-      <a [routerLink]="['./',{}]" class="tag badge-pill" [class.badge-primary]="!tag" [class.badge-dark]="tag">Všechny fotky</a>&#160;
+    <div *ngIf="tags.length" class="tags btn-group-toggle" data-toggle="buttons">
+      <label class="btn btn-outline-primary" [class.active]="!tag">
+        <input type="checkbox" checked autocomplete="off" [routerLink]="['./',{}]">Všechny fotky
+      </label>
       <ng-container *ngFor="let tagItem of tags">
-        <a [routerLink]="['./',{tag:tagItem}]" class="tag badge-pill" [class.badge-primary]="tag === tagItem" [class.badge-light]="tag !== tagItem">#{{tagItem}}</a>&#160;
+        <label class="btn btn-outline-primary" [class.active]="tag === tagItem" [ngClass]="tagClass(tagItem)">
+          <input type="checkbox" checked autocomplete="off" [routerLink]="['./',{tag:tagItem}]" class="">#{{tagItem}}
+        </label>
       </ng-container>
     </div>
 

--- a/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.html
+++ b/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.html
@@ -1,31 +1,27 @@
-<section *ngIf="album">
+<section *ngIf="album" class="py-2">
   <div *ngIf="album" class="container">
     <div class="row">
-      <div class="col-6 col-sm-2 order-1 order-sm-1">
-
-        <h2 [adminLink]="'/interni/galerie/' + album._id">
-          <a class="back" routerLink="../" tooltip="Zpět na přehled alb" placement="right"><i class="fas fa-arrow-left"></i></a>
-        </h2>
+      <div class="col-8 col-md-10">
+        <h2 [adminLink]="'/interni/galerie/' + album._id">{{album.name}}</h2>
       </div>
-      <div class="col-12 col-sm-8 order-3 order-sm-2 text-center">
-        <h2>
-          {{album.name}}
-          <ng-container *ngIf="(album.dateFrom | date:'d. M.') !== (album.dateTill | date:'d. M.'); else oneDate">({{album.dateFrom | date:"d. M."}} - {{album.dateTill | date:"d. M. y"}})</ng-container>
-          <ng-template #oneDate>({{album.dateFrom | date:"d. M. y"}})</ng-template>
-        </h2>
-      </div>
-      <div class="col-6 col-sm-2 order-2 order-sm-3">
-        <h2>
-          <div class="share">
-            <a shareUrl [shareData]="{title:album.name,text:album.description}" tooltip="Sdílet" placement="bottom"><i class="fas fa-share-alt"></i></a>
-            &nbsp;
-            <a [href]="getAlbumDownloadLink(album)" class="download font-light" download tooltip="Stáhnout celé album v ZIP" placement="bottom"><i class="fas fa-download"></i></a>
-          </div>
-        </h2>
+      <div class="col gallery-icon text-right my-auto">
+          <a shareUrl [shareData]="{title:album.name,text:album.description}" tooltip="Sdílet" placement="bottom">
+            <i class="fas fa-share-alt"></i>
+          </a>
+          &nbsp;
+          <a [href]="getAlbumDownloadLink(album)" download tooltip="Stáhnout celé album v ZIP" placement="bottom">
+            <i class="fas fa-download"></i>
+          </a>
       </div>
     </div>
     <div class="row">
       <div class="col-12">
+        <h5>
+          <ng-container *ngIf="(album.dateFrom | date:'d. M.') !== (album.dateTill | date:'d. M.'); else oneDate">
+            {{album.dateFrom | date:"d. M."}} - {{album.dateTill | date:"d. M. y"}}
+          </ng-container>
+          <ng-template #oneDate>{{album.dateFrom | date:"d. M. y"}}</ng-template>
+        </h5>
         <p>{{album.description}}</p>
       </div>
     </div>

--- a/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.html
+++ b/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.html
@@ -30,9 +30,10 @@
       <label class="btn btn-outline-primary" [class.active]="!tag">
         <input type="checkbox" checked autocomplete="off" [routerLink]="['./',{}]">Všechny fotky
       </label>
-      <ng-container *ngFor="let tagItem of tags">
-        <label class="btn btn-outline-primary" [class.active]="tag === tagItem" [ngClass]="tagClass(tagItem)">
-          <input type="checkbox" checked autocomplete="off" [routerLink]="['./',{tag:tagItem}]" class="">#{{tagItem}}
+      <ng-container *ngFor="let tagItem of tags, index as i">
+        <label class="btn btn-outline-primary"  (mouseover)="hover=tagItem" (mouseleave)="hover=null"
+               [ngStyle]="styleByTag(i, tag === tagItem, hover === tagItem)">
+          <input type="checkbox" checked autocomplete="off" [routerLink]="['./',{tag:tagItem}]">#{{tagItem}}
         </label>
       </ng-container>
     </div>

--- a/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.scss
+++ b/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.scss
@@ -15,40 +15,10 @@ a.link {
   cursor: pointer;
 }
 
-.btn {
+.btn-outline-primary {
   margin: 0.25rem;
   border-radius: 22.5px;
   font-size: 1rem;
   text-transform: none;
-}
-
-.red-button {
-  color: #bb0000;
-  border-color: #bb0000 !important;
-}
-
-.red-button:hover, .red-button.active {
-  color: $white !important;
-  background-color: #bb0000 !important;
-}
-
-.green-button{
-  color: #36802d;
-  border-color: #36802d !important;
-}
-
-.green-button:hover, .green-button.active {
-  color: $white !important;
-  background-color: #36802d !important;
-}
-
-.blue-button {
-  color: #012475;
-  border-color: #012475 !important;
-}
-
-.blue-button:hover, .blue-button.active {
-  color: $white !important;
-  background-color: #012475 !important;
 }
 

--- a/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.scss
+++ b/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.scss
@@ -1,31 +1,17 @@
 @import "~styles/variables";
 
-.tags{
-  margin:10px;
-  line-height: 2.5;
+.gallery-icon {
+  font-size: 1.5rem;
 }
-.tags a {
-  white-space: nowrap;
-}
-.share{float:right;}
-.share a{color:$linkBlue;}
 
-.container {
-  padding: 15px 0 15px 0;
+a {
+  color: $black;
+  text-decoration: none !important;
+  cursor: pointer;
 }
-.row {
-  padding: 10px;
-}
-@media (max-width: 768px) {
-  h2 {
-    font-size: 1.5rem;
-  }
-  .tags{
-    line-height: 2;
-  }
-  .badge-pill {
-    padding: .4rem .4rem;
-    font-size: .8rem;
-  }
+
+a.link {
+  color: $black !important;
+  cursor: pointer;
 }
 

--- a/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.scss
+++ b/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.scss
@@ -15,3 +15,40 @@ a.link {
   cursor: pointer;
 }
 
+.btn {
+  margin: 0.25rem;
+  border-radius: 22.5px;
+  font-size: 1rem;
+  text-transform: none;
+}
+
+.red-button {
+  color: #bb0000;
+  border-color: #bb0000 !important;
+}
+
+.red-button:hover, .red-button.active {
+  color: $white !important;
+  background-color: #bb0000 !important;
+}
+
+.green-button{
+  color: #36802d;
+  border-color: #36802d !important;
+}
+
+.green-button:hover, .green-button.active {
+  color: $white !important;
+  background-color: #36802d !important;
+}
+
+.blue-button {
+  color: #012475;
+  border-color: #012475 !important;
+}
+
+.blue-button:hover, .blue-button.active {
+  color: $white !important;
+  background-color: #012475 !important;
+}
+

--- a/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.ts
+++ b/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.ts
@@ -20,6 +20,7 @@ class GalleryPhotoContainer implements GalleryPhoto {
   caption: string;
   bg: string;
 }
+
 @Component({
   selector: 'gallery-view-album',
   templateUrl: './gallery-view-album.component.html',
@@ -31,18 +32,20 @@ export class GalleryViewAlbumComponent implements OnInit, OnDestroy {
 
   tags: string[] = [];
   tag: string;
+  hover: string;
 
   galleryPhotos: GalleryPhoto[] = [];
 
-  tagClasses = ["red-button", "green-button", "blue-button"]
+  possibleTagColors = ["#02486a", "#C2185B", "#7C4DFF", "#303F9F", "#4CAF50", "#F57C00", "#FF5722", "#FFA000", "#8BC34A"]
 
   paramsSubscription: Subscription;
 
   constructor(
-    private api: ApiService,
-    private router: Router,
-    private route: ActivatedRoute
-  ) { }
+      private api: ApiService,
+      private router: Router,
+      private route: ActivatedRoute
+  ) {
+  }
 
   ngOnInit() {
     this.paramsSubscription = this.route.params.subscribe((params: Params) => {
@@ -64,8 +67,7 @@ export class GalleryViewAlbumComponent implements OnInit, OnDestroy {
   async loadAlbum(id: string) {
     try {
       this.album = await this.api.get<Album>(["galleryalbum", id]);
-    }
-    catch (err) {
+    } catch (err) {
       this.router.navigate(["/nenalezeno"]);
     }
 
@@ -107,23 +109,21 @@ export class GalleryViewAlbumComponent implements OnInit, OnDestroy {
   }
 
   openPhoto(container: GalleryPhotoContainer) {
-    this.router.navigate(['./' + container.photo._id], { relativeTo: this.route });
+    this.router.navigate(['./' + container.photo._id], {relativeTo: this.route});
   }
 
   getAlbumDownloadLink(album: Album): string {
     return this.api.link2href(album._links.download);
   }
 
-  tagClass(tag: string){
-    let hash = 0;
-    if (tag.length === 0) return hash;
-    for (let i = 0; i < tag.length; i++) {
-      hash = tag.charCodeAt(i) + ((hash << 5) - hash);
-      hash = hash & hash;
-    }
-    let length = this.tagClasses.length;
-    hash = ((hash % length) + length) % length;
+  styleByTag(index: number, selected: boolean, hovered: boolean) {
+    let color = this.possibleTagColors[index % this.possibleTagColors.length]
 
-    return this.tagClasses[hash];
+    if (selected || hovered) {
+      return {borderColor: color, backgroundColor: color, color: "#FFFFFF"};
+    } else {
+      return {borderColor: color, color: color};
+    }
+
   }
 }

--- a/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.ts
+++ b/client/src/app/views/gallery-view/gallery-view-album/gallery-view-album.component.ts
@@ -1,13 +1,13 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {ActivatedRoute, Params, Router} from '@angular/router';
 
-import { Subscription } from "rxjs";
+import {Subscription} from "rxjs";
 
-import { ApiService } from "app/services/api.service";
+import {ApiService} from "app/services/api.service";
 
-import { Album, Photo } from "app/shared/schema/album";
+import {Album, Photo} from "app/shared/schema/album";
 
-import { GalleryPhoto } from "app/shared/components/photo-gallery/photo-gallery.component";
+import {GalleryPhoto} from "app/shared/components/photo-gallery/photo-gallery.component";
 
 class GalleryPhotoContainer implements GalleryPhoto {
 
@@ -33,6 +33,8 @@ export class GalleryViewAlbumComponent implements OnInit, OnDestroy {
   tag: string;
 
   galleryPhotos: GalleryPhoto[] = [];
+
+  tagClasses = ["red-button", "green-button", "blue-button"]
 
   paramsSubscription: Subscription;
 
@@ -112,5 +114,16 @@ export class GalleryViewAlbumComponent implements OnInit, OnDestroy {
     return this.api.link2href(album._links.download);
   }
 
+  tagClass(tag: string){
+    let hash = 0;
+    if (tag.length === 0) return hash;
+    for (let i = 0; i < tag.length; i++) {
+      hash = tag.charCodeAt(i) + ((hash << 5) - hash);
+      hash = hash & hash;
+    }
+    let length = this.tagClasses.length;
+    hash = ((hash % length) + length) % length;
 
+    return this.tagClasses[hash];
+  }
 }

--- a/client/src/app/views/gallery-view/gallery-view-photos/gallery-view-photos.component.html
+++ b/client/src/app/views/gallery-view/gallery-view-photos/gallery-view-photos.component.html
@@ -9,7 +9,6 @@
 <div class="menu" [@controlsHide]="controlsState">
   <div class="row">
     <div class="col-10 col-md-4 text-light">
-      <a (click)="close()" class="back"><i class="fas fa-arrow-left"></i></a>
       <a routerLink="../">{{album?.name}}</a>
     </div>
     <div class="d-none d-md-block col-md-4 text-center text-light count">

--- a/client/src/app/views/gallery-view/gallery-view-photos/gallery-view-photos.component.scss
+++ b/client/src/app/views/gallery-view/gallery-view-photos/gallery-view-photos.component.scss
@@ -1,4 +1,12 @@
+@import "~styles/variables";
+
 :host{position:fixed;top:0;left:0;right:0;bottom:0;z-index:10;background-color:#000;}
+
+a, a:active {
+  color: $white;
+  text-decoration: none !important;
+  cursor: pointer;
+}
 
 .images{position:fixed;top:0;left:0;width:100%;height:100%;}
 .image{position:absolute;top:0;left:0;width:100%;height:100%;background-position:center center; background-repeat:no-repeat; background-size:contain;background-color:#000;}


### PR DESCRIPTION
Trochu jsem předělal náhled na detail alba, Closes #89 

Hlavní změny:
- smazání šipky zpět jak z detailu alba tak detailu fotky, lidi mají back funkci v prohlížečích, byla nadbytečná
- barevné "oživení" tagů v albu, nyní se jim generuje barva z výčtu barev, později by mohl tenhle výčet dát @SmallhillCZ do administrace

BTW jsem to jen já nebo [FA Icons](https://fontawesome.com/v4.7.0/icons/) jsou např. oproti [Material design Icons](https://material.io/resources/icons/?style=baseline) opravdu ošklivé?
