### PR TITLE
Oprava špatně se zobrazující ikonky filtru akcí na mobilu

### DIFF
--- a/client-admin/package-lock.json
+++ b/client-admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bosancz-client-admin",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client-admin/package.json
+++ b/client-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bosancz-client-admin",
   "description": "Bošán interní sekce",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "private": true,
   "scripts": {
     "build": "ng build --prod",

--- a/client-admin/src/app/modules/events/views/events-list/events-list.component.ts
+++ b/client-admin/src/app/modules/events/views/events-list/events-list.component.ts
@@ -129,16 +129,17 @@ export class EventsListComponent implements OnInit {
 
     this.actions = [
       {
-        icon: "search-outline",
+        icon: "filter-outline",
         pinned: true,
         handler: () => this.showFilter = !this.showFilter
       },
       {
         icon: "add-outline",
         pinned: true,
-        hidden: resources["events"].allowed["POST"],
+        hidden: !resources["events"].allowed["POST"],
         handler: () => this.createEvent()
       }
+
     ];
   }
 

--- a/client-admin/src/app/shared/components/action-buttons/action-buttons.component.html
+++ b/client-admin/src/app/shared/components/action-buttons/action-buttons.component.html
@@ -1,6 +1,9 @@
 <!-- SINGLE -->
 <ion-button *ngIf="single" [color]="single.color" [disabled]="single.disabled" (click)="onClick(single)">
-  {{ single.text }}
+  <ion-icon *ngIf="!single.text && single.icon" [name]="single.icon"></ion-icon>
+  <span *ngIf="single.text && !single.icon">
+    <ion-text [color]="single.color">{{ single.text }}</ion-text>
+  </span>
 </ion-button>
 
 <!-- PINNED -->


### PR DESCRIPTION
# Změny

 - oprava ikonky filtru

# Testovací scénář

 1. Otevřít si test.bosan.cz a zkontrolovat, že verze je 3.0.5 (připadně CTRL+F5, než bude)
 2. Otevřít seznam akcí a podívat se, jestli vpravo nahoře je ikonka filtru
 3. Napsat feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)