### PR TITLE
feat: update camp to 2024, remove "naše" from ŠÁN references

### DIFF
--- a/web/src/app/views/about-view/about-view.component.html
+++ b/web/src/app/views/about-view/about-view.component.html
@@ -28,7 +28,7 @@
         <img class="card-img-top" src="assets/img/front-page/tabor_small.jpg" alt="">
         <div class="card-body text-center d-flex flex-column">
           <h3 class="card-title">Tábor na ostrově Šán</h3>
-          <p class="card-text">Každý rok si užíváme obří porci zábavy na našem ostrově uprostřed Labe. Tři týdny dobrodružství, sportovních výzev a přátel. Ke konci prázdnin také jezdíme na týdenní puťák.</p>
+          <p class="card-text">Každý rok si užíváme obří porci zábavy na ostrově uprostřed Labe. Tři týdny dobrodružství, sportovních výzev a přátel. Ke konci prázdnin také jezdíme na týdenní puťák.</p>
           <a routerLink="/tabor" class="btn btn-primary mt-auto js-scroll-trigger">Chci jet na tábor</a>
         </div>
       </div>
@@ -56,7 +56,7 @@
 
 <section class="py-4">
  <div class="container">
-    
+
     <div class="row">
      <div class="col-12 text-center mb-3">
        <h2>Kdo jsme?</h2>

--- a/web/src/app/views/camp-view/camp-view.component.html
+++ b/web/src/app/views/camp-view/camp-view.component.html
@@ -16,37 +16,37 @@
     <div class="container">
         <div class="row text-center">
             <div class="col-12">
-                <h1 class="mb-3">Letní vodácký tábor - ŠÁN 2023</h1>
-                <p class="subheading">Dětská organizace KONDOR, skupina ŠÁN připravuje na prázdniny 2023 dva turnusy
-                    letního vodáckého tábora na svém ostrově na Labi nedaleko Roudnice nad Labem. Tábor je určen
+                <h1 class="mb-3">Letní vodácký tábor - ŠÁN 2024</h1>
+                <p class="subheading">Dětská organizace KONDOR, skupina ŠÁN připravuje na prázdniny 2024 dva turnusy
+                    letního vodáckého tábora na ostrově na Labi nedaleko Roudnice nad Labem. Tábor je určen
                     všem, kteří mají rádi pohyb, jsou ve věku od 7 do 15 let a mají alespoň základy plavání (na
                     ostrově se vodě nevyhneš).</p>
             </div>
         </div>
         <div class="row text-center">
             <div class="col-12 col-md-6 mx-auto contact pb-3">
-                <h4>I. turnus (1. - 22. 7. 2023)</h4>
+                <h4>I. turnus (29. 6. - 19. 7. 2024)</h4>
                 <p class="badge badge-pill m-1 blue">4. oddíl</p>
                 <p class="badge badge-pill m-1 green">6. oddíl</p>
                 <p class="badge badge-pill m-1 yellow">8. oddíl</p>
                 <p class="badge badge-pill m-1 yellow">22. oddíl</p><br>
 
-                <h4>Vojtěška<br>Vojtěch Neumann</h4>
+                <h4>Fíla<br>Filip Hruška</h4>
                 <p class="badge badge-pill mb-1">hlavní vedoucí</p><br>
-                <a class="a-black" href="mailto:vojteska@bosan.cz">vojteska@bosan.cz</a><br>
-                <a class="a-black" href="tel:737390342">737 390 342</a><br>
+                <a class="a-black" href="mailto:fila@bosan.cz">fila@bosan.cz</a><br>
+                <a class="a-black" href="tel:774533358">774 533 358</a><br>
 
             </div>
             <div class="col-12 col-md-6 mx-auto contact pb-3">
-                <h4>II. turnus (22. 7. - 12. 8. 2023)</h4>
+                <h4>II. turnus (20. 7. - 10. 8. 2024)</h4>
                 <p class="badge badge-pill m-1 green">3. oddíl</p>
                 <p class="badge badge-pill m-1 red">5. oddíl</p>
                 <p class="badge badge-pill m-1 blue">7. oddíl</p><br>
 
-                <h4>Máčko<br>Veronika Hauerová</h4>
+                <h4>Mazák<br>David Tvrdý</h4>
                 <p class="badge badge-pill mb-1">hlavní vedoucí</p><br>
-                <a class="a-black" href="mailto:macko@bosan.cz">macko@bosan.cz</a><br>
-                <a class="a-black" href="tel:734315382">734 315 382</a><br>
+                <a class="a-black" href="mailto:mazak@bosan.cz">mazak@bosan.cz</a><br>
+                <a class="a-black" href="tel:731041415">731 041 415</a><br>
             </div>
         </div>
     </div>

--- a/web/src/app/views/camp-view/camp-view.component.html
+++ b/web/src/app/views/camp-view/camp-view.component.html
@@ -128,7 +128,7 @@
            <li>- 500,- Kč záloha splatná do 14 dní od vydání přihlášky (pro vážné zájemce) plus 4 900,- Kč
                doplatek do konce května
            </li>
-           <li>- účastníci tábora získají členské příspěvky od září do prosince 2023
+           <li>- účastníci tábora získají členské příspěvky od září do prosince 2024
                <strong>zdarma</strong>!
            </li>
        </ul>


### PR DESCRIPTION
# Změny

 - úprava sekce tábor na rok 2024, změna termínů a hlavních vedoucích (oddíly zůstávají)
 - odstranění reference na to že ŠÁN je náš

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že sedí termíny hlavní vedoucí i kontakty na ně.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)