### PR TITLE
fix: načítání ikon událostí v programu

### DIFF
--- a/web/src/app/shared/pipes/event.pipe.ts
+++ b/web/src/app/shared/pipes/event.pipe.ts
@@ -23,7 +23,7 @@ export class EventPipe implements PipeTransform {
 
       case "color":
       case "image":
-        return EventTypes[event.subtype] && EventTypes[event.subtype][property] || "";
+        return EventTypes[event.type] && EventTypes[event.type][property] || "";
 
       default:
         return "?";


### PR DESCRIPTION
# Změny

 - Ikony událostí na stránce Program se nenačítaly – v `EventPipe` (`web/src/app/shared/pipes/event.pipe.ts`) se ikona vyhledávala podle pole `event.subtype`, které veřejné API interní sekce (`/api/public/program`) už neposílá. Při migraci na nový backend bylo původní pole `subtype` (klíč ikony) sloučeno do jediného sloupce `Event.type`, takže `EventTypes[event.subtype]` bylo vždy `undefined` a u každé události se zobrazil prázdný šedý kroužek.
 - Pipe nyní čte klíč ikony z `event.type`, stejně jako to už dělá vlastní event pipe ve frontendu interní sekce. Backend tedy poskytuje všechna potřebná data – jen pod názvem `type` místo `subtype`.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že na stránce **Program** se u událostí zobrazují správné ikony podle jejich typu (např. kajak pro „voda“, kolo pro „cyklo“, stan pro „tábor“) místo prázdných šedých kroužků.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBbJhTGThrxTrVcVvrCUf8)_