### PR TITLE
Oprava odkazu na ical odběr kalendáře

### DIFF
--- a/web/src/app/components/calendar-sync-manual/calendar-sync-manual.component.html
+++ b/web/src/app/components/calendar-sync-manual/calendar-sync-manual.component.html
@@ -16,7 +16,7 @@
         <li>Otevři svou kalendářovou aplikaci (případně mailového klienta, pokud používáš kalendář v něm).</li>
         <li>Najdi tlačítko pro přidání kalendáře a klikni na něj.</li>
         <li>Pokud už se ti nenabízí možnost vložit odkaz, zkus najít něco jako „ze sítě“/„z internetu“…</li>
-        <li><b>Zkopíruj tento odkaz do políčka pro vložení url adresy: <a href="https://interni.bosan.cz/api/program/ical">https://interni.bosan.cz/api/program/ical</a>.</b></li>
+        <li><b>Zkopíruj tento odkaz do políčka pro vložení url adresy: <a [href]="icalUrl">{{ icalUrl }}</a>.</b></li>
         <li>Pokud to jde: pojmenuj si ho (třeba „Šánovské akce“), přebarvi si ho, nastav „jen pro čtení“ a interval synchronizace (po jaké době se změny v programu promítnou do tvého kalendáře).</li>
         <li>Potvrď přidání kalendáře.</li>
         <li>Jestli se ti ho předtím nepovedlo přejmenovat, můžeš najít nastavení vlastností tohoto kalendáře a upravit si ho dodatečně.</li>

--- a/web/src/app/components/calendar-sync-manual/calendar-sync-manual.component.ts
+++ b/web/src/app/components/calendar-sync-manual/calendar-sync-manual.component.ts
@@ -1,22 +1,34 @@
 import { Component, OnInit } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { ApiService } from "app/services/api.service";
+
+const FALLBACK_ICAL_URL = "https://interni.bosan.cz/api/public/program/ical";
+
 @Component({
   selector: 'calendar-sync-manual',
   templateUrl: './calendar-sync-manual.component.html',
   styleUrls: ['./calendar-sync-manual.component.scss']
 })
 export class CalendarSyncManualComponent implements OnInit {
-  
+
   title: string;
   closeBtnName: string;
   list: any[] = [];
 
+  icalUrl: string = FALLBACK_ICAL_URL;
+
   constructor(
-    public bsModalRef: BsModalRef
+    public bsModalRef: BsModalRef,
+    private api: ApiService
   ) { }
 
-  ngOnInit(): void {
+  async ngOnInit(): Promise<void> {
+    try {
+      this.icalUrl = await this.api.path2href("program:ical");
+    } catch (err) {
+      this.icalUrl = FALLBACK_ICAL_URL;
+    }
   }
 
 }


### PR DESCRIPTION
# Změny

- Návod „Jak nastavit odběr kalendáře přes ical?“ měl adresu `https://interni.bosan.cz/api/program/ical` natvrdo v šabloně a nová interní ji nepodávala — odkaz vedl do prázdna (bosancz/interni-sekce#352).
- Adresa se teď **bere z `_links` kořene API** (`program:ical`), takže když se endpoint zase někam přesune, návod se srovná sám. Natvrdo zůstává jen nová adresa `https://interni.bosan.cz/api/public/program/ical` jako záloha pro případ, že by se lookup nepovedl.

Závisí na [bosancz/interni-sekce#358](https://github.com/bosancz/interni-sekce/pull/358), které ten endpoint přidává — do jeho nasazení se použije ta záložní adresa, která začne fungovat ve stejnou chvíli.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že na stránce **Program** odkaz „odběr akcí“ otevře návod a v kroku 4 je adresa `https://interni.bosan.cz/api/public/program/ical` (jako text i jako odkaz).
3. Zkontroluj, že po kliknutí na tu adresu se stáhne `.ics` soubor s akcemi.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3H3cr1ZGK3boxU31MM2KJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3H3cr1ZGK3boxU31MM2KJ)_